### PR TITLE
Enable frontend editing for Product model

### DIFF
--- a/shop_app/cms_apps.py
+++ b/shop_app/cms_apps.py
@@ -13,5 +13,5 @@ class ShopAppHook(CMSApp):
     def get_urls(self, page=None, language=None, **kwargs):
 
         return [
-            path('<str:slug>/', views.render_product)
+            path('<str:slug>/', views.product_view)
         ]

--- a/shop_app/cms_config.py
+++ b/shop_app/cms_config.py
@@ -1,0 +1,8 @@
+from cms.app_base import CMSAppConfig
+
+from shop_app import models, views
+
+
+class ShopAppConfig(CMSAppConfig):
+    cms_enabled = True
+    cms_toolbar_enabled_models = [(models.Product, views.render_product)]

--- a/shop_app/models.py
+++ b/shop_app/models.py
@@ -25,6 +25,9 @@ class Product(models.Model):
 #   	     return self._get_placeholder_from_slot("product_description")               
         return get_placeholder_from_slot(self.placeholders, "product_description")
 
+    def get_template(self):
+        return "shop_app/product.html"
+
 
     def __str__(self):
 	    return self.product_title

--- a/shop_app/templates/shop_app/product.html
+++ b/shop_app/templates/shop_app/product.html
@@ -1,0 +1,2 @@
+{% load cms_tags %}
+{% placeholder "product_description" %}

--- a/shop_app/views.py
+++ b/shop_app/views.py
@@ -3,8 +3,14 @@ from .models import Product
 from django.http import HttpResponse, Http404
 
 # Create your views here.
-def render_product(request, slug):
+
+def render_product(request, product):
+	return render(request, 'product.html', { 'product': product, })
+
+def product_view(request, slug):
 	product = Product.objects.filter(slug=slug).first()
 	if not product:
-		raise Http404("Product does not exist")	
-	return render(request, 'product.html', { 'product': product, })
+		raise Http404("Product does not exist")
+	request.toolbar.set_object(product)
+	return render_product(request, product)
+


### PR DESCRIPTION
In response to https://github.com/django-cms/django-cms/issues/7712 here's a pull request which enables frontend editing for `Product` model. I agree this urgently needs updated docs:

Necessary steps were:
* Declaration of the `Product` model as frontend-editable in `cms_config.py`
* Adding a `get_template()` method to the model
* Adding a structure mode template for identifying the placeholders (`shop_app/product.html`)
* Adding a rendering method for the preview and edit endpoints
* Finally, to make the Preview and Edit buttons appear on the published URL: Add the product instance to the toolbar
