### PR TITLE
Second variant to enable frontend editing

### DIFF
--- a/djangocms_apphook_renderplaceholder/templates/product.html
+++ b/djangocms_apphook_renderplaceholder/templates/product.html
@@ -9,17 +9,17 @@
 
     <body>
         {% cms_toolbar %}
-        
+
         <p>Rendering product.html template</p>
 
         <p><b>product_title:</b> {{ product.product_title }}</p>
 
         <p><b>available:</b> {{ product.available }}</p>
-        
+
         <p><b>product description</b> (below should be editable through a CMS placeholder)</p>
 
-        <div style="width:600px; height:100px; background-color:lightgrey;">
-	    {% render_placeholder product.description %}
+        <div style="width:600px; height:100px; background-color:lightgrey; color:black;">
+	    {% placeholder "product_description" %}
         </div>
 
         {% render_block "js" %}

--- a/shop_app/cms_apps.py
+++ b/shop_app/cms_apps.py
@@ -13,5 +13,5 @@ class ShopAppHook(CMSApp):
     def get_urls(self, page=None, language=None, **kwargs):
 
         return [
-            path('<str:slug>/', views.render_product)
+            path('<str:slug>/', views.product_view)
         ]

--- a/shop_app/cms_config.py
+++ b/shop_app/cms_config.py
@@ -1,0 +1,8 @@
+from cms.app_base import CMSAppConfig
+
+from shop_app import models, views
+
+
+class ShopAppConfig(CMSAppConfig):
+    cms_enabled = True
+    cms_toolbar_enabled_models = [(models.Product, views.render_product)]

--- a/shop_app/models.py
+++ b/shop_app/models.py
@@ -22,9 +22,11 @@ class Product(models.Model):
 
     @cached_property
     def description(self):
-#   	     return self._get_placeholder_from_slot("product_description")               
+#   	     return self._get_placeholder_from_slot("product_description")
         return get_placeholder_from_slot(self.placeholders, "product_description")
 
+    def get_template(self):
+        return "product.html"
 
     def __str__(self):
 	    return self.product_title

--- a/shop_app/views.py
+++ b/shop_app/views.py
@@ -1,10 +1,16 @@
+from cms.utils.helpers import is_editable_model
 from django.shortcuts import render
 from .models import Product
 from django.http import HttpResponse, Http404
 
 # Create your views here.
-def render_product(request, slug):
+
+def render_product(request, product):
+	return render(request, 'product.html', { 'product': product, })
+
+def product_view(request, slug):
 	product = Product.objects.filter(slug=slug).first()
 	if not product:
-		raise Http404("Product does not exist")	
-	return render(request, 'product.html', { 'product': product, })
+		raise Http404("Product does not exist")
+	request.toolbar.set_object(product)
+	return render_product(request, product)


### PR DESCRIPTION
To avoid having a second template, you can also move the `{% placeholder %}` template tag to the template actually rendering the content (`product.html`), provided that you have set the toolbar object before (which is needed for linking the placeholder to the object). 